### PR TITLE
Add activity_threshold set to 7

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -9,16 +9,18 @@
 
 [Planet]
 
-name            = Planet SymPy
-link            = http://planet.sympy.org/
-owner_name      = Ondrej Certik
-owner_email     = ondrej@certik.cz
-output_theme    = theme
-cache_directory = cache
-output_dir      = output
-feed_timeout    = 20
-items_per_page  = 60
-log_level       = DEBUG
+name               = Planet SymPy
+link               = http://planet.sympy.org/
+owner_name         = Ondrej Certik
+owner_email        = ondrej@certik.cz
+output_theme       = theme
+cache_directory    = cache
+output_dir         = output
+feed_timeout       = 20
+items_per_page     = 60
+log_level          = DEBUG
+activity_threshold = 7
+
 
 # Subscription configuration
 


### PR DESCRIPTION
This should hopefully mark people who haven't updated their blogs in
seven days, which will be good for checking the blogging requirement for
GSoC students.  I don't have planet installed, so I can't really test
this.
